### PR TITLE
Backport patch for proper containerized NUMA support/detection

### DIFF
--- a/5.0/numa.patch
+++ b/5.0/numa.patch
@@ -1,0 +1,52 @@
+From 08ec0d4e2bf3e73229ce7a4e537a57794848d319 Mon Sep 17 00:00:00 2001
+Origin: https://github.com/ehabkost/qemu/commit/08ec0d4e2bf3e73229ce7a4e537a57794848d319
+From: Igor Mammedov <imammedo@redhat.com>
+Date: Thu, 30 Apr 2020 11:46:06 -0400
+Subject: [PATCH] hostmem: don't use mbind() if host-nodes is empty
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Since 5.0 QEMU uses hostmem backend for allocating main guest RAM.
+The backend however calls mbind() which is typically NOP
+in case of default policy/absent host-nodes bitmap.
+However when runing in container with black-listed mbind()
+syscall, QEMU fails to start with error
+ "cannot bind memory to host NUMA nodes: Operation not permitted"
+even when user hasn't provided host-nodes to pin to explictly
+(which is the case with -m option)
+
+To fix issue, call mbind() only in case when user has provided
+host-nodes explicitly (i.e. host_nodes bitmap is not empty).
+That should allow to run QEMU in containers with black-listed
+mbind() without memory pinning. If QEMU provided memory-pinning
+is required user still has to white-list mbind() in container
+configuration.
+
+Reported-by: Manuel Hohmann <mhohmann@physnet.uni-hamburg.de>
+Signed-off-by: Igor Mammedov <imammedo@redhat.com>
+Message-Id: <20200430154606.6421-1-imammedo@redhat.com>
+Tested-by: Philippe Mathieu-Daudé <philmd@redhat.com>
+Cc: qemu-stable@nongnu.org
+Signed-off-by: Eduardo Habkost <ehabkost@redhat.com>
+---
+ backends/hostmem.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/backends/hostmem.c b/backends/hostmem.c
+index 4ee43548987..61e3255f5c9 100644
+--- a/backends/hostmem.c
++++ b/backends/hostmem.c
+@@ -383,8 +383,10 @@ host_memory_backend_memory_complete(UserCreatable *uc, Error **errp)
+         assert(sizeof(backend->host_nodes) >=
+                BITS_TO_LONGS(MAX_NODES + 1) * sizeof(unsigned long));
+         assert(maxnode <= MAX_NODES);
+-        if (mbind(ptr, sz, backend->policy,
+-                  maxnode ? backend->host_nodes : NULL, maxnode + 1, flags)) {
++
++        if (maxnode &&
++            mbind(ptr, sz, backend->policy, backend->host_nodes, maxnode + 1,
++                  flags)) {
+             if (backend->policy != MPOL_DEFAULT || errno != ENOSYS) {
+                 error_setg_errno(errp, errno,
+                                  "cannot bind memory to host NUMA nodes");


### PR DESCRIPTION
Fixes #6

As discussed over in #7, this is something that's been fixed upstream, so we can backport that patch!

https://github.com/qemu/qemu/blob/ddc760832fa8cf5e93b9d9e6e854a5114ac63510/MAINTAINERS#L2196

leads to:

https://github.com/ehabkost/qemu/tree/machine-next

leads to:

https://github.com/ehabkost/qemu/commit/08ec0d4e2bf3e73229ce7a4e537a57794848d319

:metal:

(Hopefully we can drop this patch for the next release of the 5.x series. :+1:)