### PR TITLE
Enable support for RBD

### DIFF
--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -53,6 +53,7 @@ RUN set -eux; \
 		libnuma-dev \
 		libpixman-1-dev \
 		libpng-dev \
+		librbd-dev \
 		libseccomp-dev \
 		libssh-dev \
 		libusb-1.0-0-dev \
@@ -136,7 +137,8 @@ RUN set -eux; \
 		--enable-vnc-png \
 		--enable-xen \
 		--enable-xfsctl \
-#		--enable-rbd \
+# rbd support is enabled, but "librbd1" is not included since it adds ~60MB and is version-sensitive (https://github.com/tianon/docker-qemu/pull/11#issuecomment-689816553)
+		--enable-rbd \
 #		--enable-vde \
 	; \
 	make -j "$(nproc)"; \

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -53,6 +53,7 @@ RUN set -eux; \
 		libnuma-dev \
 		libpixman-1-dev \
 		libpng-dev \
+		librbd-dev \
 		libseccomp-dev \
 		libssh-dev \
 		libusb-1.0-0-dev \
@@ -136,7 +137,8 @@ RUN set -eux; \
 		--enable-vnc-png \
 		--enable-xen \
 		--enable-xfsctl \
-#		--enable-rbd \
+# rbd support is enabled, but "librbd1" is not included since it adds ~60MB and is version-sensitive (https://github.com/tianon/docker-qemu/pull/11#issuecomment-689816553)
+		--enable-rbd \
 #		--enable-vde \
 	; \
 	make -j "$(nproc)"; \

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -53,6 +53,7 @@ RUN set -eux; \
 		libnuma-dev \
 		libpixman-1-dev \
 		libpng-dev \
+		librbd-dev \
 		libseccomp-dev \
 		libssh-dev \
 		libusb-1.0-0-dev \
@@ -136,7 +137,8 @@ RUN set -eux; \
 		--enable-vnc-png \
 		--enable-xen \
 		--enable-xfsctl \
-#		--enable-rbd \
+# rbd support is enabled, but "librbd1" is not included since it adds ~60MB and is version-sensitive (https://github.com/tianon/docker-qemu/pull/11#issuecomment-689816553)
+		--enable-rbd \
 #		--enable-vde \
 	; \
 	make -j "$(nproc)"; \

--- a/5.1/Dockerfile
+++ b/5.1/Dockerfile
@@ -53,6 +53,7 @@ RUN set -eux; \
 		libnuma-dev \
 		libpixman-1-dev \
 		libpng-dev \
+		librbd-dev \
 		libseccomp-dev \
 		libssh-dev \
 		libusb-1.0-0-dev \
@@ -136,7 +137,8 @@ RUN set -eux; \
 		--enable-vnc-png \
 		--enable-xen \
 		--enable-xfsctl \
-#		--enable-rbd \
+# rbd support is enabled, but "librbd1" is not included since it adds ~60MB and is version-sensitive (https://github.com/tianon/docker-qemu/pull/11#issuecomment-689816553)
+		--enable-rbd \
 #		--enable-vde \
 	; \
 	make -j "$(nproc)"; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -47,6 +47,7 @@ RUN set -eux; \
 		libnuma-dev \
 		libpixman-1-dev \
 		libpng-dev \
+		librbd-dev \
 		libseccomp-dev \
 		libssh-dev \
 		libusb-1.0-0-dev \
@@ -130,7 +131,8 @@ RUN set -eux; \
 		--enable-vnc-png \
 		--enable-xen \
 		--enable-xfsctl \
-#		--enable-rbd \
+# rbd support is enabled, but "librbd1" is not included since it adds ~60MB and is version-sensitive (https://github.com/tianon/docker-qemu/pull/11#issuecomment-689816553)
+		--enable-rbd \
 #		--enable-vde \
 	; \
 	make -j "$(nproc)"; \


### PR DESCRIPTION
This PR adds support for Ceph/RBD, by doing the following:
* installs RBD libraries at compile time
* (re)adds the `-enable-rbd` flag to configure

This enables a basic usage such as:
```sh
sudo docker run --rm -it \
  -v /etc/ceph/ceph.conf:/etc/ceph/ceph.conf:ro \
  -v /etc/ceph/ceph.client.qemu.keyring:/etc/ceph/ceph.client.qemu.keyring:ro \
  tianon/qemu:latest \
    qemu-img create -f raw rbd:rbd/desktop:id=qemu 100G
```
Also, it enables running a VM with RBD volume:
```sh
sudo docker run --rm -it \
  --device /dev/kvm \
  -v /etc/ceph/ceph.conf:/etc/ceph/ceph.conf:ro \
  -v /etc/ceph/ceph.client.qemu.keyring:/etc/ceph/ceph.client.qemu.keyring:ro \
  -v /docker/mini.iso:/tmp/mini.iso \
  tianon/qemu:latest \
        qemu-system-x86_64 \
          -enable-kvm \
          -smp 4 \
          -m 8192 \
          -boot order=d \
          -device virtio-scsi-pci \
          -drive format=rbd,file=rbd:rbd/desktop:id=qemu,id=drive1,cache=writeback,if=none \
          -device driver=scsi-hd,drive=drive1,discard_granularity=512 \
          -netdev user,hostname=desktop,hostfwd=tcp::22-:22,id=net \
          -device virtio-net-pci,netdev=net \
          -serial stdio \
          -vnc :0 \
          -no-user-config \
          -cpu host \
          -nodefaults \
          -vga std \
          -cdrom /tmp/mini.iso
```

Note: The `librbd1` and `librados2` packages need to be installed in the image in order to use RBD devices. For those needing that, I suggest a simple script that gets mounted in the image (with `docker run -v`):
```sh
#!/usr/bin/env bash
apt-get -qq update
DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends librbd1
rm -rf /var/lib/apt/lists/*

set -x
"${@}"
```

Of course, this script can be modified to install the latest images from https://download.ceph.com/ (see https://docs.ceph.com/docs/master/install/get-packages/#configure-repositories-manually)