### PR TITLE
Add source URL to "pkgversion"

### DIFF
--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -92,6 +92,8 @@ RUN set -eux; \
 	\
 	./configure --help; \
 	./configure \
+# let's add a link to our source code in the output of "--version" in case our users end up filing bugs against the QEMU project O:)
+		--with-pkgversion='https://github.com/tianon/docker-qemu' \
 		--target-list=' \
 # system targets
 # (https://sources.debian.org/src/qemu/buster/debian/rules/#L59-L63, slimmed)

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -92,6 +92,8 @@ RUN set -eux; \
 	\
 	./configure --help; \
 	./configure \
+# let's add a link to our source code in the output of "--version" in case our users end up filing bugs against the QEMU project O:)
+		--with-pkgversion='https://github.com/tianon/docker-qemu' \
 		--target-list=' \
 # system targets
 # (https://sources.debian.org/src/qemu/buster/debian/rules/#L59-L63, slimmed)

--- a/5.1/Dockerfile
+++ b/5.1/Dockerfile
@@ -92,6 +92,8 @@ RUN set -eux; \
 	\
 	./configure --help; \
 	./configure \
+# let's add a link to our source code in the output of "--version" in case our users end up filing bugs against the QEMU project O:)
+		--with-pkgversion='https://github.com/tianon/docker-qemu' \
 		--target-list=' \
 # system targets
 # (https://sources.debian.org/src/qemu/buster/debian/rules/#L59-L63, slimmed)

--- a/5.2/Dockerfile
+++ b/5.2/Dockerfile
@@ -95,6 +95,8 @@ RUN set -eux; \
 	\
 	./configure --help; \
 	./configure \
+# let's add a link to our source code in the output of "--version" in case our users end up filing bugs against the QEMU project O:)
+		--with-pkgversion='https://github.com/tianon/docker-qemu' \
 		--target-list=' \
 # system targets
 # (https://sources.debian.org/src/qemu/buster/debian/rules/#L59-L63, slimmed)

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -91,6 +91,8 @@ RUN set -eux; \
 	\
 	./configure --help; \
 	./configure \
+# let's add a link to our source code in the output of "--version" in case our users end up filing bugs against the QEMU project O:)
+		--with-pkgversion='https://github.com/tianon/docker-qemu' \
 		--target-list=' \
 # system targets
 # (https://sources.debian.org/src/qemu/buster/debian/rules/#L59-L63, slimmed)


### PR DESCRIPTION
This should make `--version` output more helpful in any upstream bug reports so they can trace back to the source of the build.