### PR TITLE
Add `swtpm` package for easier TPM usage

### DIFF
--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -24,6 +24,9 @@ RUN set -eux; \
 	apt-get update; \
 # https://github.com/tianon/docker-qemu/issues/30
 	apt-get install -y --no-install-recommends ca-certificates; \
+# include "swtpm" for TPM emulation -- not automatically launched, but small and useful for running a TPM sidecar container (https://qemu-project.gitlab.io/qemu/specs/tpm.html#the-qemu-tpm-emulator-device)
+	apt-get install -y --no-install-recommends swtpm; \
+# install "firmware" packages (easier UEFI, etc)
 	apt-get install -y --no-install-recommends \
 # amd64
 		ovmf \

--- a/7.2/Dockerfile.native
+++ b/7.2/Dockerfile.native
@@ -24,6 +24,9 @@ RUN set -eux; \
 	apt-get update; \
 # https://github.com/tianon/docker-qemu/issues/30
 	apt-get install -y --no-install-recommends ca-certificates; \
+# include "swtpm" for TPM emulation -- not automatically launched, but small and useful for running a TPM sidecar container (https://qemu-project.gitlab.io/qemu/specs/tpm.html#the-qemu-tpm-emulator-device)
+	apt-get install -y --no-install-recommends swtpm; \
+# install "firmware" packages (easier UEFI, etc)
 	arch="$(dpkg --print-architecture)"; \
 	case "$arch" in \
 		amd64) apt-get install -y --no-install-recommends ovmf ;; \

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -24,6 +24,9 @@ RUN set -eux; \
 	apt-get update; \
 # https://github.com/tianon/docker-qemu/issues/30
 	apt-get install -y --no-install-recommends ca-certificates; \
+# include "swtpm" for TPM emulation -- not automatically launched, but small and useful for running a TPM sidecar container (https://qemu-project.gitlab.io/qemu/specs/tpm.html#the-qemu-tpm-emulator-device)
+	apt-get install -y --no-install-recommends swtpm; \
+# install "firmware" packages (easier UEFI, etc)
 	apt-get install -y --no-install-recommends \
 # amd64
 		ovmf \

--- a/8.2/Dockerfile.native
+++ b/8.2/Dockerfile.native
@@ -24,6 +24,9 @@ RUN set -eux; \
 	apt-get update; \
 # https://github.com/tianon/docker-qemu/issues/30
 	apt-get install -y --no-install-recommends ca-certificates; \
+# include "swtpm" for TPM emulation -- not automatically launched, but small and useful for running a TPM sidecar container (https://qemu-project.gitlab.io/qemu/specs/tpm.html#the-qemu-tpm-emulator-device)
+	apt-get install -y --no-install-recommends swtpm; \
+# install "firmware" packages (easier UEFI, etc)
 	arch="$(dpkg --print-architecture)"; \
 	case "$arch" in \
 		amd64) apt-get install -y --no-install-recommends ovmf ;; \

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -24,6 +24,9 @@ RUN set -eux; \
 	apt-get update; \
 # https://github.com/tianon/docker-qemu/issues/30
 	apt-get install -y --no-install-recommends ca-certificates; \
+# include "swtpm" for TPM emulation -- not automatically launched, but small and useful for running a TPM sidecar container (https://qemu-project.gitlab.io/qemu/specs/tpm.html#the-qemu-tpm-emulator-device)
+	apt-get install -y --no-install-recommends swtpm; \
+# install "firmware" packages (easier UEFI, etc)
 	apt-get install -y --no-install-recommends \
 # amd64
 		ovmf \

--- a/9.0/Dockerfile.native
+++ b/9.0/Dockerfile.native
@@ -24,6 +24,9 @@ RUN set -eux; \
 	apt-get update; \
 # https://github.com/tianon/docker-qemu/issues/30
 	apt-get install -y --no-install-recommends ca-certificates; \
+# include "swtpm" for TPM emulation -- not automatically launched, but small and useful for running a TPM sidecar container (https://qemu-project.gitlab.io/qemu/specs/tpm.html#the-qemu-tpm-emulator-device)
+	apt-get install -y --no-install-recommends swtpm; \
+# install "firmware" packages (easier UEFI, etc)
 	arch="$(dpkg --print-architecture)"; \
 	case "$arch" in \
 		amd64) apt-get install -y --no-install-recommends ovmf ;; \

--- a/9.1/Dockerfile
+++ b/9.1/Dockerfile
@@ -24,6 +24,9 @@ RUN set -eux; \
 	apt-get update; \
 # https://github.com/tianon/docker-qemu/issues/30
 	apt-get install -y --no-install-recommends ca-certificates; \
+# include "swtpm" for TPM emulation -- not automatically launched, but small and useful for running a TPM sidecar container (https://qemu-project.gitlab.io/qemu/specs/tpm.html#the-qemu-tpm-emulator-device)
+	apt-get install -y --no-install-recommends swtpm; \
+# install "firmware" packages (easier UEFI, etc)
 	apt-get install -y --no-install-recommends \
 # amd64
 		ovmf \

--- a/9.1/Dockerfile.native
+++ b/9.1/Dockerfile.native
@@ -24,6 +24,9 @@ RUN set -eux; \
 	apt-get update; \
 # https://github.com/tianon/docker-qemu/issues/30
 	apt-get install -y --no-install-recommends ca-certificates; \
+# include "swtpm" for TPM emulation -- not automatically launched, but small and useful for running a TPM sidecar container (https://qemu-project.gitlab.io/qemu/specs/tpm.html#the-qemu-tpm-emulator-device)
+	apt-get install -y --no-install-recommends swtpm; \
+# install "firmware" packages (easier UEFI, etc)
 	arch="$(dpkg --print-architecture)"; \
 	case "$arch" in \
 		amd64) apt-get install -y --no-install-recommends ovmf ;; \

--- a/9.2-rc/Dockerfile
+++ b/9.2-rc/Dockerfile
@@ -24,6 +24,9 @@ RUN set -eux; \
 	apt-get update; \
 # https://github.com/tianon/docker-qemu/issues/30
 	apt-get install -y --no-install-recommends ca-certificates; \
+# include "swtpm" for TPM emulation -- not automatically launched, but small and useful for running a TPM sidecar container (https://qemu-project.gitlab.io/qemu/specs/tpm.html#the-qemu-tpm-emulator-device)
+	apt-get install -y --no-install-recommends swtpm; \
+# install "firmware" packages (easier UEFI, etc)
 	apt-get install -y --no-install-recommends \
 # amd64
 		ovmf \

--- a/9.2-rc/Dockerfile.native
+++ b/9.2-rc/Dockerfile.native
@@ -24,6 +24,9 @@ RUN set -eux; \
 	apt-get update; \
 # https://github.com/tianon/docker-qemu/issues/30
 	apt-get install -y --no-install-recommends ca-certificates; \
+# include "swtpm" for TPM emulation -- not automatically launched, but small and useful for running a TPM sidecar container (https://qemu-project.gitlab.io/qemu/specs/tpm.html#the-qemu-tpm-emulator-device)
+	apt-get install -y --no-install-recommends swtpm; \
+# install "firmware" packages (easier UEFI, etc)
 	arch="$(dpkg --print-architecture)"; \
 	case "$arch" in \
 		amd64) apt-get install -y --no-install-recommends ovmf ;; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -26,6 +26,9 @@ RUN set -eux; \
 	riscv64: "opensbi u-boot-qemu",
 # TODO add u-boot-qemu to more arches?  https://packages.debian.org/bookworm/u-boot-qemu
 } -}}
+# include "swtpm" for TPM emulation -- not automatically launched, but small and useful for running a TPM sidecar container (https://qemu-project.gitlab.io/qemu/specs/tpm.html#the-qemu-tpm-emulator-device)
+	apt-get install -y --no-install-recommends swtpm; \
+# install "firmware" packages (easier UEFI, etc)
 {{ if env.variant == "native" then ( -}}
 	arch="$(dpkg --print-architecture)"; \
 	case "$arch" in \


### PR DESCRIPTION
This doesn't make using a TPM with QEMU any more ergonomic, but it does make it a lot easier to pre-launch a TPM sidecar container that shares a unix socket with a QEMU container such that running a VM with a TPM *is* easier (and it's really tiny / low storage cost).

See also https://qemu-project.gitlab.io/qemu/specs/tpm.html#the-qemu-tpm-emulator-device