### PR TITLE
Add 11.0.0-rc0

### DIFF
--- a/11.0-rc/Dockerfile
+++ b/11.0-rc/Dockerfile
@@ -1,0 +1,215 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM debian:trixie-slim
+
+RUN set -eux; \
+# add backports for (potentially) newer QEMU firmware packages
+	if grep backports /etc/apt/sources.list.d/debian.sources; then exit 1; fi; \
+	sed -ri -e 's/([[:space:]])([^[:space:]]+)-updates($|[[:space:]])/\0\1\2-backports\3/' /etc/apt/sources.list.d/debian.sources; \
+	grep backports /etc/apt/sources.list.d/debian.sources; \
+# and add APT pinning to ensure we don't accidentally get QEMU from Debian
+	{ \
+		echo 'Package: src:edk2'; \
+		echo 'Pin: release a=*-backports'; \
+		echo 'Pin-Priority: 600'; \
+		echo; \
+		echo 'Package: src:qemu'; \
+		echo 'Pin: version *'; \
+		echo 'Pin-Priority: -10'; \
+	} > /etc/apt/preferences.d/qemu.pref; \
+	apt-get update; \
+# https://github.com/tianon/docker-qemu/issues/30
+	apt-get install -y --no-install-recommends ca-certificates; \
+# include "swtpm" for TPM emulation -- not automatically launched, but small and useful for running a TPM sidecar container (https://qemu-project.gitlab.io/qemu/specs/tpm.html#the-qemu-tpm-emulator-device)
+	apt-get install -y --no-install-recommends swtpm; \
+# install "firmware" packages (easier UEFI, etc)
+	apt-get install -y --no-install-recommends \
+# amd64
+		ovmf \
+# arm64
+		qemu-efi-aarch64 \
+# armel | armhf
+		qemu-efi-arm \
+# i386
+		ovmf-ia32 \
+# riscv64
+		opensbi u-boot-qemu \
+	; \
+	apt-get dist-clean
+
+COPY *.patch /qemu-patches/
+
+# https://wiki.qemu.org/SecurityProcess
+ENV QEMU_KEYS \
+# Michael Roth
+		CEACC9E15534EBABB82D3FA03353C9CEF108B584
+# https://wiki.qemu.org/Planning/ReleaseProcess#Sign_the_resulting_tarball_with_GPG: (they get signed by whoever is making the release)
+
+# https://www.qemu.org/download/#source
+# https://download.qemu.org/?C=M;O=D
+ENV QEMU_VERSION 11.0.0-rc0
+ENV QEMU_URL https://download.qemu.org/qemu-11.0.0-rc0.tar.xz
+
+RUN set -eux; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get install --update -y --no-install-recommends \
+		gnupg \
+		wget \
+		xz-utils \
+		\
+		patch \
+		\
+		bzip2 \
+		gcc \
+		gnutls-dev \
+		libaio-dev \
+		libbz2-dev \
+		libc-dev \
+		libcap-dev \
+		libcap-ng-dev \
+		libcurl4-gnutls-dev \
+		libglib2.0-dev \
+		libiscsi-dev \
+		libjpeg-dev \
+		libncursesw5-dev \
+		libnfs-dev \
+		libnuma-dev \
+		libpixman-1-dev \
+		libpng-dev \
+		librbd-dev \
+		libseccomp-dev \
+		libssh-dev \
+		libusb-1.0-0-dev \
+		libusbredirparser-dev \
+		libxen-dev \
+		make \
+		pkg-config \
+		python3 \
+		zlib1g-dev \
+# https://wiki.qemu.org/ChangeLog/5.2#Build_Information
+		ninja-build \
+		python3-setuptools \
+# https://www.qemu.org/2021/08/22/fuse-blkexport/
+		libfuse3-dev \
+# https://wiki.qemu.org/ChangeLog/7.2#Removal_of_the_.22slirp.22_submodule_.28affects_.22-netdev_user.22.29
+		libslirp-dev \
+# https://wiki.qemu.org/ChangeLog/8.1#Build_Dependencies
+		python3-venv \
+# "../meson.build:3070:18: ERROR: Git program not found, cannot download dtc.wrap via git."
+		git \
+	; \
+	\
+	tarball="$(basename "$QEMU_URL")"; \
+	wget -O "$tarball.sig" "$QEMU_URL.sig"; \
+	wget -O "$tarball" "$QEMU_URL" --progress=dot:giga; \
+	\
+	export GNUPGHOME="$(mktemp -d)"; \
+	for key in $QEMU_KEYS; do \
+		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+	done; \
+	gpg --batch --verify "$tarball.sig" "$tarball"; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME"; \
+	\
+	mkdir /usr/src/qemu; \
+	tar -xf "$tarball" -C /usr/src/qemu --strip-components=1; \
+	rm "$tarball" "$tarball.sig"; \
+	\
+	cd /usr/src/qemu; \
+	\
+	for p in /qemu-patches/*.patch; do \
+		patch --strip 1 --input "$p"; \
+	done; \
+	rm -rf /qemu-patches; \
+	\
+	./configure --help; \
+	./configure \
+# let's add a link to our source code in the output of "--version" in case our users end up filing bugs against the QEMU project O:)
+		--with-pkgversion='https://github.com/tianon/docker-qemu' \
+		--target-list=' \
+# system targets
+# (https://sources.debian.org/src/qemu/buster/debian/rules/#L59-L63, slimmed)
+			i386-softmmu x86_64-softmmu aarch64-softmmu arm-softmmu m68k-softmmu \
+			mips64-softmmu mips64el-softmmu ppc64-softmmu riscv64-softmmu \
+			sparc64-softmmu s390x-softmmu \
+		' \
+# let's point "firmware path" to Debian's value so we get access to "OVMF.fd" and friends more easily
+		--firmwarepath=/usr/share/qemu:/usr/share/seabios:/usr/lib/ipxe/qemu \
+# https://salsa.debian.org/qemu-team/qemu/-/blob/058ab4ec8623766b50055c8c56d0d5448d52fb0a/debian/rules#L38
+		--disable-docs \
+		--disable-gtk --disable-vte \
+		--disable-sdl \
+		--enable-attr \
+		--enable-bzip2 \
+		--enable-cap-ng \
+		--enable-curl \
+		--enable-curses \
+		--enable-fdt \
+		--enable-gnutls \
+		--enable-kvm \
+		--enable-libiscsi \
+		--enable-libnfs \
+		--enable-libssh \
+		--enable-libusb \
+		--enable-linux-aio \
+		--enable-modules \
+		--enable-numa \
+		--enable-rbd \
+		--enable-seccomp \
+		--enable-strip \
+		--enable-tools \
+		--enable-usb-redir \
+		--enable-vhost-net \
+		--enable-vhost-user \
+		--enable-vhost-vdpa \
+		--enable-virtfs \
+		--enable-vnc \
+		--enable-vnc-jpeg \
+		--enable-xen \
+# rbd support is enabled, but "librbd1" is not included since it adds ~60MB and is version-sensitive (https://github.com/tianon/docker-qemu/pull/11#issuecomment-689816553)
+#		--enable-vde \
+# https://www.qemu.org/2021/08/22/fuse-blkexport/
+		--enable-fuse \
+# https://wiki.qemu.org/ChangeLog/7.2#Removal_of_the_.22slirp.22_submodule_.28affects_.22-netdev_user.22.29
+		--enable-slirp \
+	; \
+	make -j "$(nproc)"; \
+	make install; \
+	\
+	cd /; \
+	rm -rf /usr/src/qemu; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	find /usr/local \
+		-type f \
+		\( -executable -o -name '*.so' \) \
+# rbd support is enabled, but "librbd1" is not included since it adds ~60MB and is version-sensitive (https://github.com/tianon/docker-qemu/pull/11#issuecomment-689816553)
+		-not -name 'block-rbd.so' \
+		-exec ldd '{}' ';' \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
+		| sort -u \
+		| xargs -r dpkg-query --search \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -r apt-mark manual \
+	; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	apt-get dist-clean; \
+	\
+# basic smoke test
+	qemu-img --version
+
+STOPSIGNAL SIGHUP
+
+EXPOSE 22
+EXPOSE 5900
+
+COPY start-qemu /usr/local/bin/
+CMD ["start-qemu"]

--- a/11.0-rc/Dockerfile.native
+++ b/11.0-rc/Dockerfile.native
@@ -1,0 +1,218 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM debian:trixie-slim
+
+RUN set -eux; \
+# add backports for (potentially) newer QEMU firmware packages
+	if grep backports /etc/apt/sources.list.d/debian.sources; then exit 1; fi; \
+	sed -ri -e 's/([[:space:]])([^[:space:]]+)-updates($|[[:space:]])/\0\1\2-backports\3/' /etc/apt/sources.list.d/debian.sources; \
+	grep backports /etc/apt/sources.list.d/debian.sources; \
+# and add APT pinning to ensure we don't accidentally get QEMU from Debian
+	{ \
+		echo 'Package: src:edk2'; \
+		echo 'Pin: release a=*-backports'; \
+		echo 'Pin-Priority: 600'; \
+		echo; \
+		echo 'Package: src:qemu'; \
+		echo 'Pin: version *'; \
+		echo 'Pin-Priority: -10'; \
+	} > /etc/apt/preferences.d/qemu.pref; \
+	apt-get update; \
+# https://github.com/tianon/docker-qemu/issues/30
+	apt-get install -y --no-install-recommends ca-certificates; \
+# include "swtpm" for TPM emulation -- not automatically launched, but small and useful for running a TPM sidecar container (https://qemu-project.gitlab.io/qemu/specs/tpm.html#the-qemu-tpm-emulator-device)
+	apt-get install -y --no-install-recommends swtpm; \
+# install "firmware" packages (easier UEFI, etc)
+	arch="$(dpkg --print-architecture)"; \
+	case "$arch" in \
+		amd64) apt-get install -y --no-install-recommends ovmf ;; \
+		arm64) apt-get install -y --no-install-recommends qemu-efi-aarch64 ;; \
+		armel | armhf) apt-get install -y --no-install-recommends qemu-efi-arm ;; \
+		i386) apt-get install -y --no-install-recommends ovmf-ia32 ;; \
+		riscv64) apt-get install -y --no-install-recommends opensbi u-boot-qemu ;; \
+		*) echo >&2 "warning: architecture '$arch' unknown 😅 (is there a 'QEMU firmware' package that should be installed here? likely candidates: https://packages.debian.org/source/$suite/edk2)" ;; \
+	esac; \
+	apt-get dist-clean
+
+COPY *.patch /qemu-patches/
+
+# https://wiki.qemu.org/SecurityProcess
+ENV QEMU_KEYS \
+# Michael Roth
+		CEACC9E15534EBABB82D3FA03353C9CEF108B584
+# https://wiki.qemu.org/Planning/ReleaseProcess#Sign_the_resulting_tarball_with_GPG: (they get signed by whoever is making the release)
+
+# https://www.qemu.org/download/#source
+# https://download.qemu.org/?C=M;O=D
+ENV QEMU_VERSION 11.0.0-rc0
+ENV QEMU_URL https://download.qemu.org/qemu-11.0.0-rc0.tar.xz
+
+RUN set -eux; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get install --update -y --no-install-recommends \
+		gnupg \
+		wget \
+		xz-utils \
+		\
+		patch \
+		\
+		bzip2 \
+		gcc \
+		gnutls-dev \
+		libaio-dev \
+		libbz2-dev \
+		libc-dev \
+		libcap-dev \
+		libcap-ng-dev \
+		libcurl4-gnutls-dev \
+		libglib2.0-dev \
+		libiscsi-dev \
+		libjpeg-dev \
+		libncursesw5-dev \
+		libnfs-dev \
+		libnuma-dev \
+		libpixman-1-dev \
+		libpng-dev \
+		librbd-dev \
+		libseccomp-dev \
+		libssh-dev \
+		libusb-1.0-0-dev \
+		libusbredirparser-dev \
+		libxen-dev \
+		make \
+		pkg-config \
+		python3 \
+		zlib1g-dev \
+# https://wiki.qemu.org/ChangeLog/5.2#Build_Information
+		ninja-build \
+		python3-setuptools \
+# https://www.qemu.org/2021/08/22/fuse-blkexport/
+		libfuse3-dev \
+# https://wiki.qemu.org/ChangeLog/7.2#Removal_of_the_.22slirp.22_submodule_.28affects_.22-netdev_user.22.29
+		libslirp-dev \
+# https://wiki.qemu.org/ChangeLog/8.1#Build_Dependencies
+		python3-venv \
+# "../meson.build:3070:18: ERROR: Git program not found, cannot download dtc.wrap via git."
+		git \
+	; \
+	\
+	tarball="$(basename "$QEMU_URL")"; \
+	wget -O "$tarball.sig" "$QEMU_URL.sig"; \
+	wget -O "$tarball" "$QEMU_URL" --progress=dot:giga; \
+	\
+	export GNUPGHOME="$(mktemp -d)"; \
+	for key in $QEMU_KEYS; do \
+		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+	done; \
+	gpg --batch --verify "$tarball.sig" "$tarball"; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME"; \
+	\
+	mkdir /usr/src/qemu; \
+	tar -xf "$tarball" -C /usr/src/qemu --strip-components=1; \
+	rm "$tarball" "$tarball.sig"; \
+	\
+	cd /usr/src/qemu; \
+	\
+	for p in /qemu-patches/*.patch; do \
+		patch --strip 1 --input "$p"; \
+	done; \
+	rm -rf /qemu-patches; \
+	\
+	arch="$(dpkg --print-architecture)"; \
+	case "$arch" in \
+		amd64) targetList='x86_64-softmmu' ;; \
+		arm64) targetList='aarch64-softmmu' ;; \
+		armel | armhf) targetList='arm-softmmu' ;; \
+		i386) targetList='i386-softmmu' ;; \
+		mips64el) targetList='mips64el-softmmu' ;; \
+		ppc64el) targetList='ppc64-softmmu' ;; \
+		s390x) targetList='s390x-softmmu' ;; \
+		*) echo >&2 "error: architecture '$arch' unimplemented 😅"; exit 1 ;; \
+	esac; \
+	\
+	./configure --help; \
+	./configure \
+# let's add a link to our source code in the output of "--version" in case our users end up filing bugs against the QEMU project O:)
+		--with-pkgversion='https://github.com/tianon/docker-qemu' \
+		--target-list="$targetList" \
+# let's point "firmware path" to Debian's value so we get access to "OVMF.fd" and friends more easily
+		--firmwarepath=/usr/share/qemu:/usr/share/seabios:/usr/lib/ipxe/qemu \
+# https://salsa.debian.org/qemu-team/qemu/-/blob/058ab4ec8623766b50055c8c56d0d5448d52fb0a/debian/rules#L38
+		--disable-docs \
+		--disable-gtk --disable-vte \
+		--disable-sdl \
+		--enable-attr \
+		--enable-bzip2 \
+		--enable-cap-ng \
+		--enable-curl \
+		--enable-curses \
+		--enable-fdt \
+		--enable-gnutls \
+		--enable-kvm \
+		--enable-libiscsi \
+		--enable-libnfs \
+		--enable-libssh \
+		--enable-libusb \
+		--enable-linux-aio \
+		--enable-modules \
+		--enable-numa \
+		--enable-rbd \
+		--enable-seccomp \
+		--enable-strip \
+		--enable-tools \
+		--enable-usb-redir \
+		--enable-vhost-net \
+		--enable-vhost-user \
+		--enable-vhost-vdpa \
+		--enable-virtfs \
+		--enable-vnc \
+		--enable-vnc-jpeg \
+		--enable-xen \
+# rbd support is enabled, but "librbd1" is not included since it adds ~60MB and is version-sensitive (https://github.com/tianon/docker-qemu/pull/11#issuecomment-689816553)
+#		--enable-vde \
+# https://www.qemu.org/2021/08/22/fuse-blkexport/
+		--enable-fuse \
+# https://wiki.qemu.org/ChangeLog/7.2#Removal_of_the_.22slirp.22_submodule_.28affects_.22-netdev_user.22.29
+		--enable-slirp \
+	; \
+	make -j "$(nproc)"; \
+	make install; \
+	\
+	cd /; \
+	rm -rf /usr/src/qemu; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	find /usr/local \
+		-type f \
+		\( -executable -o -name '*.so' \) \
+# rbd support is enabled, but "librbd1" is not included since it adds ~60MB and is version-sensitive (https://github.com/tianon/docker-qemu/pull/11#issuecomment-689816553)
+		-not -name 'block-rbd.so' \
+		-exec ldd '{}' ';' \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
+		| sort -u \
+		| xargs -r dpkg-query --search \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -r apt-mark manual \
+	; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	apt-get dist-clean; \
+	\
+# basic smoke test
+	qemu-img --version
+
+STOPSIGNAL SIGHUP
+
+EXPOSE 22
+EXPOSE 5900
+
+COPY start-qemu /usr/local/bin/
+CMD ["start-qemu"]

--- a/11.0-rc/qemu-signals.patch
+++ b/11.0-rc/qemu-signals.patch
@@ -1,0 +1,20 @@
+Origin: https://bugs.launchpad.net/qemu/+bug/1217339/comments/2
+Origin: https://lists.nongnu.org/archive/html/qemu-devel/2017-03/msg03039.html
+
+diff --git a/system/runstate.c b/system/runstate.c
+index 6178b0091a..dda0d43c1b 100644
+--- a/system/runstate.c
++++ b/system/runstate.c
+@@ -780,8 +780,12 @@ void qemu_system_killed(int signal, pid_t pid)
+     /* Cannot call qemu_system_shutdown_request directly because
+      * we are in a signal handler.
+      */
++    if (signal == SIGHUP) {
++        powerdown_requested = 1;
++    } else { // indentation of the following is "wrong" on purpose so the patch diff is smaller (and the relation to the original code more obvious)
+     shutdown_requested = SHUTDOWN_CAUSE_HOST_SIGNAL;
+     force_shutdown = true;
++    }
+     qemu_notify_event();
+ }
+ 

--- a/11.0-rc/start-qemu
+++ b/11.0-rc/start-qemu
@@ -1,0 +1,112 @@
+#!/bin/bash
+set -e
+
+# main available options:
+#   QEMU_CPU=n    (cores)
+#   QEMU_RAM=nnn  (megabytes)
+#   QEMU_HDA      (filename)
+#   QEMU_HDA_SIZE (bytes, suffixes like "G" allowed)
+#   QEMU_CDROM    (filename)
+#   QEMU_BOOT     (-boot)
+#   QEMU_PORTS="xxx[ xxx ...]" (space separated port numbers)
+#   QEMU_NET_USER_EXTRA="net=192.168.76.0/24,dhcpstart=192.168.76.9" (extra raw args for "-net user,...")
+#   QEMU_NO_NET=1 (suppress ALL -netdev - thus no port forwards, etc)
+#   QEMU_NO_SSH=1 (suppress automatic port 22 forwarding)
+#   QEMU_NO_SERIAL=1 (suppress automatic "-serial stdio")
+#   QEMU_NO_VNC=1 (suppress automatic "-vnc ':0'")
+
+hostArch="$(uname -m)"
+qemuArch="${QEMU_ARCH:-$hostArch}"
+qemu="${QEMU_BIN:-qemu-system-$qemuArch}"
+qemuArgs=()
+
+qemuPorts=()
+if [ -z "${QEMU_NO_SSH:-}" ]; then
+	qemuPorts+=( 22 )
+fi
+qemuPorts+=( ${QEMU_PORTS:-} )
+
+if [ -e /dev/kvm ] && sh -c 'echo -n > /dev/kvm' &> /dev/null; then
+	# https://github.com/tianon/docker-qemu/issues/4
+	qemuArgs+=( -enable-kvm )
+elif [ "$hostArch" = "$qemuArch" ]; then
+	echo >&2
+	echo >&2 'warning: /dev/kvm not found'
+	echo >&2 '  PERFORMANCE WILL SUFFER'
+	echo >&2 '  (hint: docker run --device /dev/kvm ...)'
+	echo >&2
+	sleep 3
+fi
+
+qemuArgs+=( -smp "${QEMU_CPU:-1}" )
+qemuArgs+=( -m "${QEMU_RAM:-512}" )
+
+if [ -n "${QEMU_HDA:-}" ]; then
+	if [ ! -f "$QEMU_HDA" -o ! -s "$QEMU_HDA" ]; then
+		(
+			set -x
+			qemu-img create -f qcow2 -o preallocation=off "$QEMU_HDA" "${QEMU_HDA_SIZE:-8G}"
+		)
+	fi
+
+	# http://wiki.qemu.org/download/qemu-doc.html#Invocation
+	qemuScsiDevice='virtio-scsi-pci'
+	case "$qemuArch" in
+		arm | riscv64) qemuScsiDevice='virtio-scsi-device' ;;
+	esac
+
+	#qemuArgs+=( -hda "$QEMU_HDA" )
+	#qemuArgs+=( -drive file="$QEMU_HDA",index=0,media=disk,discard=unmap )
+	qemuArgs+=(
+		-drive file="$QEMU_HDA",index=0,media=disk,discard=unmap,detect-zeroes=unmap,if=none,id=hda
+		-device "$qemuScsiDevice"
+		-device scsi-hd,drive=hda
+	)
+fi
+
+if [ -n "${QEMU_CDROM:-}" ]; then
+	qemuArgs+=( -cdrom "$QEMU_CDROM" )
+fi
+
+if [ -n "${QEMU_BOOT:-}" ]; then
+	qemuArgs+=( -boot "$QEMU_BOOT" )
+fi
+
+if [ -z "${QEMU_NO_NET:-}" ]; then
+	netArg='user'
+	netArg+=",hostname=$(hostname)"
+	if [ -n "${QEMU_NET_USER_EXTRA:-}" ]; then
+		netArg+=",$QEMU_NET_USER_EXTRA"
+	fi
+	for port in "${qemuPorts[@]}"; do
+		netArg+=",hostfwd=tcp::$port-:$port"
+		netArg+=",hostfwd=udp::$port-:$port"
+	done
+
+	qemuNetDevice='virtio-net-pci'
+	case "$qemuArch" in
+		arm | riscv64) qemuNetDevice='virtio-net-device' ;;
+	esac
+
+	qemuArgs+=(
+		-netdev "$netArg,id=net"
+		-device "$qemuNetDevice,netdev=net"
+	)
+fi
+
+if [ -z "${QEMU_NO_SERIAL:-}" ]; then
+	qemuArgs+=(
+		-serial stdio
+	)
+fi
+
+if [ -z "${QEMU_NO_VNC:-}" ]; then
+	qemuArgs+=(
+		-vnc ':0'
+	)
+fi
+
+qemuArgs+=( "$@" )
+
+set -x
+exec "$qemu" "${qemuArgs[@]}"

--- a/versions.json
+++ b/versions.json
@@ -11,6 +11,10 @@
     "url": "https://download.qemu.org/qemu-10.2.2.tar.xz",
     "version": "10.2.2"
   },
+  "11.0-rc": {
+    "url": "https://download.qemu.org/qemu-11.0.0-rc0.tar.xz",
+    "version": "11.0.0-rc0"
+  },
   "7.2": {
     "url": "https://download.qemu.org/qemu-7.2.22.tar.xz",
     "version": "7.2.22"


### PR DESCRIPTION
With this release, 7.2 has technically dropped off the download page again, but I bet that's an oversight (as 7.2 has historically been an "LTS" release, and it's had recent releases; see also https://gitlab.com/qemu-project/qemu-web/-/commit/79626a87fb8a21adb5919218becc5fad9f179bab).